### PR TITLE
[__main__] fix `index` access to `unapproved_servers`

### DIFF
--- a/src/contextprotector/__main__.py
+++ b/src/contextprotector/__main__.py
@@ -79,6 +79,7 @@ async def _launch_review(
             guardrail_provider,
             args.quarantine_path,
         )
+
 async def main_async() -> None:
     """Launch the wrapped server or review process specified in arguments."""
     args = _parse_args()
@@ -269,7 +270,6 @@ async def list_unapproved_configs(config_path: str | None = None) -> None:
             print("  [q] Quit")
 
             choice = input("\nEnter your choice: ").strip().lower()
-
             if choice == "q":
                 break
             if choice == "a":
@@ -302,7 +302,7 @@ async def list_unapproved_configs(config_path: str | None = None) -> None:
                 continue
             index = _int_or_none(choice)
             if isinstance(index, int) and 1 <= index <= len(unapproved_servers):
-                server = unapproved_servers[index]
+                server = unapproved_servers[index-1]
                 print(f"\nReviewing: [{server['type'].upper()}] {server['identifier']}")
 
                 # Call the existing review function


### PR DESCRIPTION
Trying to review default `server-filesystem` _MCP_ server results in an `IndexError`:
```
./mcp-context-protector.sh --review-all-servers

Found 1 unapproved server configuration(s):

1. [STDIO] npx -y @modelcontextprotocol/server-filesystem /Users/cpu/Desktop /Users/cpu/Downloads
   Status: Configuration available for review

Options:
  [1-1] Review and approve a specific server
  [a] Approve all servers
  [q] Quit

Enter your choice: 1
Traceback (most recent call last):
  File "/Users/cpu/Dev/mcp-context-protector/.venv/bin/mcp-context-protector", line 10, in <module>
    sys.exit(main())
             ~~~~^^
  File "/Users/cpu/Dev/mcp-context-protector/src/contextprotector/__main__.py", line 336, in main
    asyncio.run(main_async())
    ~~~~~~~~~~~^^^^^^^^^^^^^^
  File "/opt/homebrew/Cellar/python@3.13/3.13.5/Frameworks/Python.framework/Versions/3.13/lib/python3.13/asyncio/runners.py", line 195, in run
    return runner.run(main)
           ~~~~~~~~~~^^^^^^
  File "/opt/homebrew/Cellar/python@3.13/3.13.5/Frameworks/Python.framework/Versions/3.13/lib/python3.13/asyncio/runners.py", line 118, in run
    return self._loop.run_until_complete(task)
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^
  File "/opt/homebrew/Cellar/python@3.13/3.13.5/Frameworks/Python.framework/Versions/3.13/lib/python3.13/asyncio/base_events.py", line 725, in run_until_complete
    return future.result()
           ~~~~~~~~~~~~~^^
  File "/Users/cpu/Dev/mcp-context-protector/src/contextprotector/__main__.py", line 101, in main_async
    await list_unapproved_configs(args.server_config_file)
  File "/Users/cpu/Dev/mcp-context-protector/src/contextprotector/__main__.py", line 305, in list_unapproved_configs
    server = unapproved_servers[index]
             ~~~~~~~~~~~~~~~~~~^^^^^^^
IndexError: list index out of range
```

This change addresses the indexing that should start at 0. 