### PR TITLE
[guardrail_provider] unify `LlamaFirewall` naming

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ __pycache__/
 .idea
 html/
 dist/
+uv.lock

--- a/src/contextprotector/guardrail_providers/llama_firewall.py
+++ b/src/contextprotector/guardrail_providers/llama_firewall.py
@@ -1,4 +1,4 @@
-"""Llama Firewall guardrail provider for mcp-context-protector.
+"""LlamaFirewall guardrail provider for mcp-context-protector.
 
 Provides server configuration checking capabilities.
 """
@@ -21,23 +21,23 @@ logger = logging.getLogger("llama_firewall_provider")
 
 
 class LlamaFirewallProvider(GuardrailProvider):
-    """Llama Firewall guardrail provider.
+    """LlamaFirewall guardrail provider.
 
-    Checks server configurations against Llama Firewall guardrails.
+    Checks server configurations against LlamaFirewall guardrails.
     """
 
     def __init__(self) -> None:
-        """Initialize the Llama Firewall provider."""
+        """Initialize the LlamaFirewall provider."""
         logger.info("Initializing LlamaFirewallProvider")
         super().__init__()
 
     @property
     def name(self) -> str:
         """Get the provider name."""
-        return "Llama Firewall"
+        return "LlamaFirewall"
 
     def check_server_config(self, config: MCPServerConfig) -> GuardrailAlert | None:
-        """Check the provided server configuration against Llama Firewall guardrails.
+        """Check the provided server configuration against LlamaFirewall guardrails.
 
         Args:
         ----
@@ -64,7 +64,7 @@ class LlamaFirewallProvider(GuardrailProvider):
             message = UserMessage(content=config_str)
             logger.info("Created UserMessage for scanning")
 
-            logger.info("Scanning config with Llama Firewall...")
+            logger.info("Scanning config with LlamaFirewall...")
             result = lf.scan(message)
 
             logger.info("Scan result decision: %s", result.decision)
@@ -100,7 +100,7 @@ class LlamaFirewallProvider(GuardrailProvider):
         return alert
 
     def check_tool_response(self, tool_response: ToolResponse) -> GuardrailAlert | None:
-        """Check the provided tool response against Llama Firewall guardrails.
+        """Check the provided tool response against LlamaFirewall guardrails.
 
         Args:
         ----
@@ -120,7 +120,7 @@ class LlamaFirewallProvider(GuardrailProvider):
 
             message = ToolMessage(content=tool_response.tool_output)
 
-            logger.info("Scanning tool response with Llama Firewall...")
+            logger.info("Scanning tool response with LlamaFirewall...")
             result = lf.scan(message)
 
             logger.info("Scan result decision: %s", result.decision)

--- a/test/test_guardrails_loading.py
+++ b/test/test_guardrails_loading.py
@@ -24,13 +24,13 @@ def test_load_guardrail_providers() -> None:
     # Get provider names
     providers = get_provider_names()
 
-    # We should have at least one provider (Llama Firewall)
-    assert "Llama Firewall" in providers, "Llama Firewall provider not found"
+    # We should have at least one provider (LlamaFirewall)
+    assert "LlamaFirewall" in providers, "LlamaFirewall provider not found"
 
     # Try to get a provider instance
-    provider = get_provider("Llama Firewall")
-    assert provider is not None, "Failed to instantiate Llama Firewall provider"
-    assert provider.name == "Llama Firewall"
+    provider = get_provider("LlamaFirewall")
+    assert provider is not None, "Failed to instantiate LlamaFirewall provider"
+    assert provider.name == "LlamaFirewall"
 
 
 def test_get_nonexistent_provider() -> None:
@@ -43,9 +43,9 @@ def test_provider_check_server_config() -> None:
     """Test that a provider can check a server config and log the results."""
     from contextprotector.mcp_config import MCPServerConfig, MCPToolDefinition
 
-    # Get the Llama Firewall provider
-    provider = get_provider("Llama Firewall")
-    assert provider is not None, "Failed to get Llama Firewall provider"
+    # Get the LlamaFirewall provider
+    provider = get_provider("LlamaFirewall")
+    assert provider is not None, "Failed to get LlamaFirewall provider"
     logger.info("Got provider: %s", provider.name)
 
     # Create a simple config to check


### PR DESCRIPTION
# Description
There are a few instances where `LlamaFirewall` is written `Llama Firewall`. I think that using a uniform pattern is better.

Also added `uv.lock` to be ignored from committing.

# Tests
```
make test TESTS="test_guardrails_loading"
uv run pytest --cov=contextprotector  -x -k test_guardrails_loading
================================================================================= test session starts =================================================================================
platform darwin -- Python 3.13.5, pytest-8.4.1, pluggy-1.6.0
rootdir: /Users/cpu/Dev/mcp-context-protector
configfile: pytest.ini
plugins: anyio-4.9.0, asyncio-1.1.0, timeout-2.4.0, cov-6.2.1
asyncio: mode=Mode.STRICT, asyncio_default_fixture_loop_scope=function, asyncio_default_test_loop_scope=function
collected 84 items / 81 deselected / 3 selected

test/test_guardrails_loading.py ...                                                                                                                                             [100%]

=================================================================================== tests coverage ====================================================================================
__________________________________________________________________ coverage: platform darwin, python 3.13.5-final-0 ___________________________________________________________________

Name                                                         Stmts   Miss  Cover
--------------------------------------------------------------------------------
src/contextprotector/__init__.py                                 1      0   100%
src/contextprotector/__main__.py                               141    141     0%
src/contextprotector/guardrail_providers/__init__.py             0      0   100%
src/contextprotector/guardrail_providers/llama_firewall.py      57     31    46%
src/contextprotector/guardrail_providers/mock_provider.py       62     27    56%
src/contextprotector/guardrail_types.py                         23      4    83%
src/contextprotector/guardrails.py                              47      4    91%
src/contextprotector/mcp_config.py                             426    313    27%
src/contextprotector/mcp_wrapper.py                            668    615     8%
src/contextprotector/quarantine.py                             115     77    33%
src/contextprotector/quarantine_cli.py                          78     78     0%
--------------------------------------------------------------------------------
TOTAL                                                         1618   1290    20%
========================================================================== 3 passed, 81 deselected in 2.89s ===========================================================================
uv run coverage report -m
Name                                                         Stmts   Miss  Cover   Missing
------------------------------------------------------------------------------------------
src/contextprotector/__init__.py                                 1      0   100%
src/contextprotector/__main__.py                               141    141     0%   7-340
src/contextprotector/guardrail_providers/__init__.py             0      0   100%
src/contextprotector/guardrail_providers/llama_firewall.py      57     31    46%   70-91, 100, 114-161
src/contextprotector/guardrail_providers/mock_provider.py       62     27    56%   40-44, 48-50, 64-79, 93-110, 148-149, 170-171, 211
src/contextprotector/guardrail_types.py                         23      4    83%   56-57, 71, 86
src/contextprotector/guardrails.py                              47      4    91%   70, 90-93
src/contextprotector/mcp_config.py                             426    313    27%   40-48, 66-68, 94-118, 122-140, 156, 166-218, 237-242, 253-269, 276, 280-283, 301-311, 334-349, 353, 384-415, 419-434, 438-531, 548, 553, 557-561, 565-569, 573-574, 578, 582, 588-612, 618-620, 640-642, 653-658, 662-689, 693-716, 731-737, 757-780, 796-804, 814, 839, 855-863, 873, 897-900, 919-926, 942-951, 970-973, 991-996, 1014-1037
src/contextprotector/mcp_wrapper.py                            668    615     8%   40, 74-77, 103-106, 132-135, 156-177, 181-535, 546-589, 610-644, 648-731, 741, 760, 775-788, 802-837, 847-886, 899-938, 955-1005, 1011-1025, 1029-1038, 1042-1107, 1111-1116, 1120-1159, 1163-1189, 1193-1220, 1224-1272, 1277-1337, 1345-1360, 1377-1380, 1398-1422, 1426-1436, 1440-1483, 1508-1593, 1603
src/contextprotector/quarantine.py                             115     77    33%   28-29, 62-63, 67-71, 76-80, 84, 88-90, 110-112, 123-128, 132-142, 146-161, 181-197, 211, 226-235, 249-253, 272, 297-304, 319-335
src/contextprotector/quarantine_cli.py                          78     78     0%   3-134
------------------------------------------------------------------------------------------
TOTAL                                                         1618   1290    20%
```
