### PR TITLE
Fix dependabot config: uv ecosystem, weekly schedule, cooldown

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,14 +1,17 @@
 version: 2
 
 updates:
-  - package-ecosystem: pip
+  - package-ecosystem: uv
     directory: /
     groups:
       python:
         patterns:
           - "*"
     schedule:
-      interval: daily
+      interval: weekly
+      day: monday
+    cooldown:
+      default-days: 7
 
   - package-ecosystem: github-actions
     directory: /
@@ -17,4 +20,7 @@ updates:
         patterns:
           - "*"
     schedule:
-      interval: daily
+      interval: weekly
+      day: monday
+    cooldown:
+      default-days: 7


### PR DESCRIPTION
## Summary
- Change `package-ecosystem` from `pip` to `uv` (repo uses `uv.lock` and `[tool.uv]` in pyproject.toml)
- Change schedule from `daily` to `weekly` (Monday)
- Add `cooldown: default-days: 7` to both ecosystem entries

## Test plan
- [ ] Verify Dependabot picks up the new config and uses the uv ecosystem
- [ ] Confirm weekly schedule takes effect on next Monday

🤖 Generated with [Claude Code](https://claude.com/claude-code)