### PR TITLE
refactor: replace bare ValueError raises with typed exception hierarchy

### DIFF
--- a/src/contextprotector/__init__.py
+++ b/src/contextprotector/__init__.py
@@ -1,3 +1,29 @@
 """contextprotector package that provides an MCP security wrapper."""
 
 __version__ = "0.1.0"
+
+from .errors import (
+    ChildServerNotConnectedError,
+    ConfigConversionError,
+    ConfigLoadError,
+    ConfigValidationError,
+    ConnectionConfigError,
+    ConnectionFailedError,
+    ContextProtectorError,
+    QuarantineError,
+    ServerPinMismatchError,
+    ToolBlockedError,
+)
+
+__all__ = [
+    "ChildServerNotConnectedError",
+    "ConfigConversionError",
+    "ConfigLoadError",
+    "ConfigValidationError",
+    "ConnectionConfigError",
+    "ConnectionFailedError",
+    "ContextProtectorError",
+    "QuarantineError",
+    "ServerPinMismatchError",
+    "ToolBlockedError",
+]

--- a/src/contextprotector/errors.py
+++ b/src/contextprotector/errors.py
@@ -1,0 +1,89 @@
+"""Custom exception classes for MCP Context Protector.
+
+Replaces generic ValueError raises with semantically meaningful exception types
+to give callers a stable, type-aware way to handle different failure modes.
+"""
+
+from __future__ import annotations
+
+import json
+
+
+class ContextProtectorError(Exception):
+    """Base exception for all MCP Context Protector errors."""
+
+
+# Configuration errors ----------------------------------------------------
+
+
+class ConfigValidationError(ContextProtectorError, ValueError):
+    """Configuration parameters are missing, invalid, or inconsistent."""
+
+
+class ConfigLoadError(ContextProtectorError, ValueError):
+    """Configuration file could not be loaded or parsed."""
+
+    def __init__(self, message: str, *, path: str | None = None) -> None:
+        """Create a ConfigLoadError with an optional file path.
+
+        Args:
+            message: Human-readable error description.
+            path: Optional path to the configuration file that failed to load.
+
+        """
+        super().__init__(message)
+        self.path = path
+
+
+class ConfigConversionError(ContextProtectorError, ValueError):
+    """Server specification cannot be converted to the requested format."""
+
+
+# Connection errors -------------------------------------------------------
+
+
+class ConnectionConfigError(ContextProtectorError, ValueError):
+    """Connection parameters are missing or invalid for the requested connection type."""
+
+
+class ConnectionFailedError(ContextProtectorError, ConnectionError):
+    """A connection to the downstream MCP server could not be established."""
+
+
+class ChildServerNotConnectedError(ConnectionFailedError):
+    """Raised when the child MCP server is not connected."""
+
+    def __init__(self) -> None:
+        """Initialize with a default message about the unconnected child server."""
+        super().__init__("Child MCP server not connected")
+
+
+# Operational / runtime errors --------------------------------------------
+
+
+class ToolBlockedError(ContextProtectorError, RuntimeError):
+    """A tool invocation was blocked by the guardrail or approval system.
+
+    The message is a JSON-encoded response dict with `status` and `reason` fields
+    and can be parsed by the MCP client.
+    """
+
+    def __init__(self, blocked_response: str | dict) -> None:
+        """Create a ToolBlockedError from a JSON string or dict.
+
+        Args:
+            blocked_response: A JSON-encoded string or dictionary describing
+                the blocked tool with `status` and `reason` fields.
+
+        """
+        if isinstance(blocked_response, dict):
+            blocked_response = json.dumps(blocked_response)
+        super().__init__(blocked_response)
+
+
+class ServerPinMismatchError(ContextProtectorError, RuntimeError):
+    """Server configuration has changed since it was last approved."""
+
+
+class QuarantineError(ContextProtectorError, RuntimeError):
+    """A tool response could not be quarantined."""

--- a/src/contextprotector/mcp_config.py
+++ b/src/contextprotector/mcp_config.py
@@ -8,6 +8,8 @@ from dataclasses import dataclass, field
 from enum import Enum
 from typing import Any, Literal, TextIO
 
+from .errors import ConfigValidationError
+
 
 class ParameterType(str, Enum):
     """Types of MCP tool parameters."""
@@ -207,7 +209,7 @@ class ConfigDiff:
                     for param_name, param_changes in changes["modified_params"].items():
                         lines.append(f"      ~ {param_name}:")
                         for field, values in param_changes.items():
-                            lines.append(f"        {field}: {values['old']} → {values['new']}")
+                            lines.append(f"        {field}: {values['old']} â†’ {values['new']}")
 
         return "\n".join(lines)
 
@@ -327,7 +329,7 @@ class MCPServerConfig:
         """
         if sum(x is not None for x in (json_str, path, fp)) != 1:
             msg = "Exactly one of json_str, path, or fp must be provided"
-            raise ValueError(msg)
+            raise ConfigValidationError(msg)
 
         data = None
         if path:

--- a/src/contextprotector/mcp_json_cli.py
+++ b/src/contextprotector/mcp_json_cli.py
@@ -7,6 +7,7 @@ import sys
 from dataclasses import dataclass
 
 from .cli_utils import confirm_prompt, display_colored_diff, print_separator, truncate_text
+from .errors import ConfigValidationError
 from .mcp_json_config import (
     MCPConfigManagerFactory,
     MCPConfigSchema,
@@ -100,7 +101,7 @@ class EnvironmentSelector:
                 return cli_environment
             else:
                 available = ", ".join(environments)
-                raise ValueError(
+                raise ConfigValidationError(
                     f"Environment '{cli_environment}' not found. Available: {available}"
                 )
 

--- a/src/contextprotector/mcp_json_config.py
+++ b/src/contextprotector/mcp_json_config.py
@@ -9,6 +9,8 @@ from abc import ABC, abstractmethod
 from dataclasses import dataclass, field
 from typing import Any, ClassVar, TextIO
 
+from .errors import ConfigValidationError
+
 # Constants for command pattern detection
 MIN_ARGS_FOR_COMMAND_PATTERN = 2
 
@@ -497,21 +499,21 @@ class MCPServerSpec:
     def from_dict(cls, data: dict[str, Any]) -> "MCPServerSpec":
         """Create from a dictionary representation."""
         if not isinstance(data, dict):
-            raise ValueError("Server specification must be a dictionary")
+            raise ConfigValidationError("Server specification must be a dictionary")
 
         command = data.get("command")
         if not command or not isinstance(command, str):
-            raise ValueError("Server specification must have a valid 'command' field")
+            raise ConfigValidationError("Server specification must have a valid 'command' field")
 
         args = data.get("args", [])
         if not isinstance(args, list) or not all(isinstance(arg, str) for arg in args):
-            raise ValueError("Server 'args' must be a list of strings")
+            raise ConfigValidationError("Server 'args' must be a list of strings")
 
         env = data.get("env", {})
         if not isinstance(env, dict) or not all(
             isinstance(k, str) and isinstance(v, str) for k, v in env.items()
         ):
-            raise ValueError("Server 'env' must be a dictionary of string key-value pairs")
+            raise ConfigValidationError("Server 'env' must be a dictionary of string key-value pairs")
 
         return cls(command=command, args=args, env=env)
 
@@ -533,7 +535,7 @@ class MCPServerSpec:
         """
         # Check if already using context protector
         if MCPContextProtectorDetector.is_context_protector_configured(self):
-            raise ValueError("Server is already configured to use MCP Context Protector")
+            raise ConfigValidationError("Server is already configured to use MCP Context Protector")
 
         return MCPContextProtectorDetector.suggest_context_protector_command(
             self, installation_path
@@ -556,7 +558,7 @@ class MCPServerSpec:
         """
         # Check if using context protector
         if not MCPContextProtectorDetector.is_context_protector_configured(self):
-            raise ValueError("Server is not configured to use MCP Context Protector")
+            raise ConfigValidationError("Server is not configured to use MCP Context Protector")
 
         # Try to extract the original command from different patterns
 
@@ -608,7 +610,7 @@ class MCPServerSpec:
                         continue
 
         # If we can't parse it, raise an error
-        raise ValueError(
+        raise ConfigValidationError(
             "Cannot automatically extract original server command from context protector "
             "configuration. The server appears to use context protector but in an "
             "unrecognized pattern."
@@ -617,12 +619,12 @@ class MCPServerSpec:
     def _extract_from_command_args(self) -> "MCPServerSpec":
         """Extract original command from --command-args pattern."""
         if not self.args or "--command-args" not in self.args:
-            raise ValueError("Expected --command-args in arguments")
+            raise ConfigValidationError("Expected --command-args in arguments")
 
         try:
             command_args_index = self.args.index("--command-args")
             if command_args_index + 1 >= len(self.args):
-                raise ValueError("No command found after --command-args")
+                raise ConfigValidationError("No command found after --command-args")
 
             # Extract original command and args
             original_command = self.args[command_args_index + 1]
@@ -630,7 +632,7 @@ class MCPServerSpec:
 
             return MCPServerSpec(command=original_command, args=original_args, env=self.env.copy())
         except (ValueError, IndexError) as e:
-            raise ValueError(f"Could not parse --command-args pattern: {e}") from e
+            raise ConfigValidationError(f"Could not parse --command-args pattern: {e}") from e
 
     def _extract_from_uv_run(self, run_index: int = 0) -> "MCPServerSpec":
         """Extract original command from uv run pattern.
@@ -644,19 +646,19 @@ class MCPServerSpec:
         remaining_args = self.args[run_index + 2 :]  # Skip "run" and "mcp-context-protector"
 
         if not remaining_args or "--command-args" not in remaining_args:
-            raise ValueError("Expected --command-args in uv run pattern")
+            raise ConfigValidationError("Expected --command-args in uv run pattern")
 
         try:
             command_args_index = remaining_args.index("--command-args")
             if command_args_index + 1 >= len(remaining_args):
-                raise ValueError("No command found after --command-args")
+                raise ConfigValidationError("No command found after --command-args")
 
             original_command = remaining_args[command_args_index + 1]
             original_args = remaining_args[command_args_index + 2 :]
 
             return MCPServerSpec(command=original_command, args=original_args, env=self.env.copy())
         except (ValueError, IndexError) as e:
-            raise ValueError(f"Could not parse uv run pattern: {e}") from e
+            raise ConfigValidationError(f"Could not parse uv run pattern: {e}") from e
 
     def _extract_from_python_module(self) -> "MCPServerSpec":
         """Extract original command from python -m contextprotector pattern."""
@@ -664,19 +666,19 @@ class MCPServerSpec:
         remaining_args = self.args[2:]  # Skip "-m" and "contextprotector"
 
         if not remaining_args or "--command-args" not in remaining_args:
-            raise ValueError("Expected --command-args in python -m pattern")
+            raise ConfigValidationError("Expected --command-args in python -m pattern")
 
         try:
             command_args_index = remaining_args.index("--command-args")
             if command_args_index + 1 >= len(remaining_args):
-                raise ValueError("No command found after --command-args")
+                raise ConfigValidationError("No command found after --command-args")
 
             original_command = remaining_args[command_args_index + 1]
             original_args = remaining_args[command_args_index + 2 :]
 
             return MCPServerSpec(command=original_command, args=original_args, env=self.env.copy())
         except (ValueError, IndexError) as e:
-            raise ValueError(f"Could not parse python -m pattern: {e}") from e
+            raise ConfigValidationError(f"Could not parse python -m pattern: {e}") from e
 
     def _extract_from_shell_pattern(self, start_index: int) -> "MCPServerSpec":
         """Extract original command from shell command pattern."""
@@ -694,7 +696,7 @@ class MCPServerSpec:
                     command=original_command, args=original_args, env=self.env.copy()
                 )
 
-        raise ValueError("Could not locate original command in shell pattern")
+        raise ConfigValidationError("Could not locate original command in shell pattern")
 
 
 @dataclass
@@ -720,14 +722,14 @@ class MCPJsonConfig:
 
         """
         if not name or not isinstance(name, str):
-            raise ValueError("Server name must be a non-empty string")
+            raise ConfigValidationError("Server name must be a non-empty string")
 
         if isinstance(server, dict):
             self.mcp_servers[name] = MCPServerSpec.from_dict(server)
         elif isinstance(server, MCPServerSpec):
             self.mcp_servers[name] = server
         else:
-            raise ValueError("Server must be either an MCPServerSpec object or a dictionary")
+            raise ConfigValidationError("Server must be either an MCPServerSpec object or a dictionary")
 
     def remove_server(self, name: str) -> None:
         """Remove an MCP server from the configuration by name."""
@@ -777,23 +779,23 @@ class MCPJsonConfig:
             return config
 
         if not isinstance(data, dict):
-            raise ValueError("Configuration data must be a dictionary")
+            raise ConfigValidationError("Configuration data must be a dictionary")
 
         # Parse mcpServers section
         mcp_servers_data = data.get("mcpServers", {})
         if not isinstance(mcp_servers_data, dict):
-            raise ValueError("'mcpServers' must be a dictionary")
+            raise ConfigValidationError("'mcpServers' must be a dictionary")
 
         for name, server_data in mcp_servers_data.items():
             try:
                 config.add_server(name, server_data)
             except ValueError as e:
-                raise ValueError(f"Invalid server configuration for '{name}': {e}") from e
+                raise ConfigValidationError(f"Invalid server configuration for '{name}': {e}") from e
 
         # Parse global shortcut
         global_shortcut = data.get("globalShortcut")
         if global_shortcut is not None and not isinstance(global_shortcut, str):
-            raise ValueError("'globalShortcut' must be a string")
+            raise ConfigValidationError("'globalShortcut' must be a string")
         config.global_shortcut = global_shortcut
 
         # Store other configuration keys
@@ -853,7 +855,7 @@ class MCPJsonConfig:
         write_path = path or self.filename
 
         if not write_path:
-            raise ValueError("No path provided and configuration has no filename")
+            raise ConfigValidationError("No path provided and configuration has no filename")
 
         self.to_json(path=write_path, indent=indent)
 
@@ -886,7 +888,7 @@ class MCPJsonConfig:
         """
         if sum(x is not None for x in (json_str, path, fp)) != 1:
             msg = "Exactly one of json_str, path, or fp must be provided"
-            raise ValueError(msg)
+            raise ConfigValidationError(msg)
 
         data = None
         source_filename = None
@@ -1032,7 +1034,7 @@ class StandardMCPSchema(MCPConfigSchema):
     ) -> dict[str, MCPServerSpec]:
         """Extract servers from standard mcpServers structure."""
         if environment is not None:
-            raise ValueError("Standard schema does not support environments")
+            raise ConfigValidationError("Standard schema does not support environments")
 
         servers = {}
         mcp_servers = data.get("mcpServers", {})
@@ -1050,7 +1052,7 @@ class StandardMCPSchema(MCPConfigSchema):
     ) -> dict[str, Any]:
         """Update servers in standard mcpServers structure."""
         if environment is not None:
-            raise ValueError("Standard schema does not support environments")
+            raise ConfigValidationError("Standard schema does not support environments")
 
         updated_data = data.copy()
         updated_data["mcpServers"] = {name: server.to_dict() for name, server in servers.items()}
@@ -1098,7 +1100,7 @@ class ProjectMCPSchema(MCPConfigSchema):
                 return {}
 
         if environment not in projects:
-            raise ValueError(f"Project '{environment}' not found")
+            raise ConfigValidationError(f"Project '{environment}' not found")
 
         servers = {}
         project_data = projects[environment]
@@ -1119,11 +1121,11 @@ class ProjectMCPSchema(MCPConfigSchema):
         if environment is None:
             environment = self.get_default_environment(data)
             if environment is None:
-                raise ValueError("No project specified and no default found")
+                raise ConfigValidationError("No project specified and no default found")
 
         projects = data.get("projects", {})
         if environment not in projects:
-            raise ValueError(f"Project '{environment}' not found")
+            raise ConfigValidationError(f"Project '{environment}' not found")
 
         updated_data = data.copy()
         updated_data["projects"] = projects.copy()
@@ -1169,7 +1171,7 @@ class SchemaDetector:
             if schema.detect_schema(data):
                 return schema
 
-        raise ValueError("Unknown or invalid MCP configuration schema")
+        raise ConfigValidationError("Unknown or invalid MCP configuration schema")
 
 
 class MCPUnifiedConfig:
@@ -1219,24 +1221,24 @@ class MCPUnifiedConfig:
     def set_environment(self, environment: str) -> None:
         """Set the current environment."""
         if not self.schema:
-            raise ValueError("Configuration not loaded")
+            raise ConfigValidationError("Configuration not loaded")
 
         environments = self.schema.list_environments(self.raw_data)
         if environments and environment not in environments:
-            raise ValueError(f"Environment '{environment}' not found. Available: {environments}")
+            raise ConfigValidationError(f"Environment '{environment}' not found. Available: {environments}")
 
         self.environment = environment
 
     def get_servers(self) -> dict[str, MCPServerSpec]:
         """Get MCP servers for the current environment."""
         if not self.schema:
-            raise ValueError("Configuration not loaded")
+            raise ConfigValidationError("Configuration not loaded")
         return self.schema.get_servers(self.raw_data, self.environment)
 
     def set_servers(self, servers: dict[str, MCPServerSpec]) -> None:
         """Update MCP servers for the current environment."""
         if not self.schema:
-            raise ValueError("Configuration not loaded")
+            raise ConfigValidationError("Configuration not loaded")
         self.raw_data = self.schema.set_servers(self.raw_data, servers, self.environment)
 
     def save(self, indent: int = 2) -> None:

--- a/src/contextprotector/mcp_wrapper.py
+++ b/src/contextprotector/mcp_wrapper.py
@@ -13,6 +13,14 @@ from mcp.shared.exceptions import McpError
 from mcp.shared.session import RequestResponder
 from pydantic import AnyUrl
 
+from .errors import (
+    ChildServerNotConnectedError,
+    ConnectionConfigError,
+    ConnectionFailedError,
+    QuarantineError,
+    ToolBlockedError,
+)
+
 # ContentBlock import removed - using types.Content instead
 # Import guardrail types for type hints
 from .guardrail_types import GuardrailAlert, GuardrailProvider, ToolResponse
@@ -30,14 +38,6 @@ from .quarantine import ToolResponseQuarantine
 from .wrapper_config import MCPWrapperConfig
 
 logger = logging.getLogger("mcp_wrapper")
-
-
-class ChildServerNotConnectedError(ConnectionError):
-    """Raised when the child MCP server is not connected."""
-
-    def __init__(self) -> None:
-        """Initialize error message."""
-        super().__init__("Child MCP server not connected")
 
 
 class MCPWrapperServer:
@@ -76,7 +76,7 @@ class MCPWrapperServer:
         elif config.url is not None:  # http or sse
             instance.server_url = AnyUrl(config.url)
         else:
-            raise ValueError
+            raise ConnectionConfigError
 
         instance.visualize_ansi_codes = config.visualize_ansi_codes
 
@@ -234,7 +234,7 @@ class MCPWrapperServer:
             except McpError as e:
                 logger.exception("Error fetching resource %s from downstream server", name)
                 error_msg = f"Error fetching resource from downstream server: {e!s}"
-                raise ConnectionError(error_msg) from e
+                raise ConnectionFailedError(error_msg) from e
 
         @self.server.list_tools()
         async def list_tools() -> list[types.Tool]:
@@ -371,7 +371,7 @@ class MCPWrapperServer:
             except McpError as e:
                 logger.exception("Error from downstream server during prompt dispatch")
                 error_msg = f"Error from downstream server: {e!s}"
-                raise ConnectionError(error_msg) from e
+                raise ConnectionFailedError(error_msg) from e
 
         @self.server.call_tool()
         async def call_tool(
@@ -402,7 +402,7 @@ class MCPWrapperServer:
                     "reason": "Server approval status not initialized. Try reconnecting.",
                 }
                 error_json = json.dumps(blocked_response)
-                raise ValueError(error_json)
+                raise ToolBlockedError(error_json)
 
             # Check if server is completely new or instructions changed
             if self.approval_status.get("is_new_server", False):
@@ -415,7 +415,7 @@ class MCPWrapperServer:
                     ),
                 }
                 error_json = json.dumps(blocked_response)
-                raise ValueError(error_json)
+                raise ToolBlockedError(error_json)
 
             # Check instructions approval - but differentiate between never-approved
             # and changed instructions
@@ -442,7 +442,7 @@ class MCPWrapperServer:
                     }
                 error_json = json.dumps(blocked_response)
                 error_json = json.dumps(blocked_response)
-                raise ValueError(error_json)
+                raise ToolBlockedError(error_json)
 
             # Check if this specific tool is approved
             # Only block if the tool exists in our config but is not approved
@@ -458,7 +458,7 @@ class MCPWrapperServer:
                     ),
                 }
                 error_json = json.dumps(blocked_response)
-                raise ValueError(error_json)
+                raise ToolBlockedError(error_json)
 
             # Tool is approved, proxy the call
             try:
@@ -498,7 +498,7 @@ class MCPWrapperServer:
             except McpError as e:
                 logger.exception("Error from child MCP server")
                 error_msg = f"Error from child MCP server: {e!s}"
-                raise ConnectionError(error_msg) from e
+                raise ConnectionFailedError(error_msg) from e
 
     async def _handle_context_protector_block(self) -> list[types.TextContent]:
         """Handle the context-protector-block tool call.
@@ -575,11 +575,11 @@ Note: This tool is only available when tools are blocked due to security restric
         """
         if "uuid" not in arguments:
             msg = "Missing required parameter 'uuid' for quarantine_release tool"
-            raise ValueError(msg)
+            raise QuarantineError(msg)
 
         if self.quarantine is None:
             msg = "Quarantine not initialized"
-            raise ValueError(msg)
+            raise ConnectionConfigError(msg)
 
         response_id = arguments["uuid"]
         logger.info("Processing quarantine_release request for UUID: %s", response_id)
@@ -588,7 +588,7 @@ Note: This tool is only available when tools are blocked due to security restric
 
         if not quarantined_response:
             error_msg = f"No quarantined response found with UUID: {response_id}"
-            raise ValueError(error_msg)
+            raise QuarantineError(error_msg)
 
         if quarantined_response.released:
             original_tool_info = {
@@ -693,7 +693,7 @@ Note: This tool is only available when tools are blocked due to security restric
         except McpError as e:
             logger.exception("Error calling downstream tool '%s'", name)
             error_msg = f"Error calling downstream tool: {e!s}"
-            raise ConnectionError(error_msg) from e
+            raise ConnectionFailedError(error_msg) from e
 
     def _create_tool_response(
         self,
@@ -984,7 +984,7 @@ Note: This tool is only available when tools are blocked due to security restric
 
             if not downstream_tools.tools:
                 msg = "No tools received from downstream server"
-                raise ValueError(msg)
+                raise ConnectionConfigError(msg)
             logger.info("Received %d tools after update notification", len(downstream_tools.tools))
 
             await self._handle_tool_updates(downstream_tools.tools)
@@ -1016,7 +1016,7 @@ Note: This tool is only available when tools are blocked due to security restric
         downstream_tools = await self.session.list_tools()
         if not downstream_tools.tools:
             msg = "No tools received from downstream server during initialization"
-            raise ValueError(msg)
+            raise ConnectionConfigError(msg)
 
         self.tool_specs = self._convert_mcp_tools_to_specs(downstream_tools.tools)
 
@@ -1085,12 +1085,12 @@ Note: This tool is only available when tools are blocked due to security restric
         if self.connection_type in ["http", "sse"] and self.server_url is not None:
             return str(self.server_url)
         error_msg = f"Unknown connection type: {self.connection_type}"
-        raise ValueError(error_msg)
+        raise ConnectionConfigError(error_msg)
 
     async def _connect_via_stdio(self) -> None:
         """Connect to a downstream server via stdio."""
         if self.child_command is None:
-            raise ValueError("child_command must be set for stdio connection")
+            raise ConnectionConfigError("child_command must be set for stdio connection")
 
         logger.info("Connecting to downstream server via stdio: %s", self.child_command)
 
@@ -1108,7 +1108,7 @@ Note: This tool is only available when tools are blocked due to security restric
             command_parts = self.child_command.split()
             if not command_parts:
                 msg = "Invalid command"
-                raise ValueError(msg)
+                raise ConnectionConfigError(msg)
 
             server_params = StdioServerParameters(
                 command=command_parts[0],
@@ -1136,7 +1136,7 @@ Note: This tool is only available when tools are blocked due to security restric
     async def _connect_via_http(self) -> None:
         """Connect to a downstream server via SSE (Server-Sent Events)."""
         if self.server_url is None:
-            raise ValueError("server_url must be set for SSE connection")
+            raise ConnectionConfigError("server_url must be set for SSE connection")
 
         logger.info("Connecting to downstream server via SSE: %s", self.server_url)
 
@@ -1169,7 +1169,7 @@ Note: This tool is only available when tools are blocked due to security restric
     async def _connect_via_streamable_http(self) -> None:
         """Connect to a downstream server via streamable HTTP."""
         if self.server_url is None:
-            raise ValueError("server_url must be set for streamable HTTP connection")
+            raise ConnectionConfigError("server_url must be set for streamable HTTP connection")
 
         logger.info("Connecting to downstream server via streamable HTTP: %s", self.server_url)
 

--- a/src/contextprotector/wrapper_config.py
+++ b/src/contextprotector/wrapper_config.py
@@ -9,6 +9,7 @@ import argparse
 from dataclasses import dataclass, field
 from typing import Any, Literal
 
+from .errors import ConnectionConfigError
 from .guardrails import GuardrailProvider
 
 
@@ -64,20 +65,20 @@ class MCPWrapperConfig:
         if self.connection_type == "stdio":
             if self.command is None:
                 msg = "command must be provided for stdio connections"
-                raise ValueError(msg)
+                raise ConnectionConfigError(msg)
             if self.url is not None:
                 msg = "url should not be provided for stdio connections"
-                raise ValueError(msg)
+                raise ConnectionConfigError(msg)
         elif self.connection_type in ("http", "sse"):
             if self.url is None:
                 msg = f"url must be provided for {self.connection_type} connections"
-                raise ValueError(msg)
+                raise ConnectionConfigError(msg)
             if self.command is not None:
                 msg = f"command should not be provided for {self.connection_type} connections"
-                raise ValueError(msg)
+                raise ConnectionConfigError(msg)
         else:
             msg = f"Invalid connection_type: {self.connection_type}"
-            raise ValueError(msg)
+            raise ConnectionConfigError(msg)
 
     def _compute_server_identifier(self) -> str:
         """Compute the server identifier based on connection type and parameters."""
@@ -85,7 +86,7 @@ class MCPWrapperConfig:
             return self.command
         if self.url is not None:
             return self.url
-        raise ValueError
+        raise ConnectionConfigError
 
     @classmethod
     def from_args(
@@ -123,7 +124,7 @@ class MCPWrapperConfig:
                 "No valid connection type found in arguments. "
                 "Must provide command, url, or sse_url."
             )
-            raise ValueError(msg)
+            raise ConnectionConfigError(msg)
 
         # Set additional properties from args
         if hasattr(args, "server_config_file") and args.server_config_file:

--- a/test/test_cli_argument_parsing.py
+++ b/test/test_cli_argument_parsing.py
@@ -6,6 +6,7 @@ from unittest.mock import patch
 import pytest
 
 from contextprotector.__main__ import _parse_args
+from contextprotector.errors import ConnectionConfigError
 from contextprotector.wrapper_config import MCPWrapperConfig
 
 
@@ -208,7 +209,7 @@ class TestArgumentParsingEdgeCases:
         with patch.object(sys, "argv", ["mcp-context-protector"]):
             args = _parse_args()
             # This should work (parsing), but config creation should fail
-            with pytest.raises(ValueError, match="No valid connection type found"):
+            with pytest.raises(ConnectionConfigError, match="No valid connection type found"):
                 MCPWrapperConfig.from_args(args)
 
     def test_url_and_command_args_both_provided(self):

--- a/test/test_mcp_json_config.py
+++ b/test/test_mcp_json_config.py
@@ -6,6 +6,7 @@ from pathlib import Path
 
 import pytest
 
+from contextprotector.errors import ConfigValidationError
 from contextprotector.mcp_json_config import (
     MCPContextProtectorDetector,
     MCPJsonConfig,
@@ -78,7 +79,7 @@ class TestMCPServerSpec:
 
     def test_from_dict_invalid_data_type(self):
         """Test error handling for invalid data type."""
-        with pytest.raises(ValueError, match="Server specification must be a dictionary"):
+        with pytest.raises(ConfigValidationError, match="Server specification must be a dictionary"):
             MCPServerSpec.from_dict("not a dict")
 
     def test_from_dict_missing_command(self):
@@ -97,10 +98,10 @@ class TestMCPServerSpec:
 
     def test_from_dict_invalid_args(self):
         """Test error handling for invalid args."""
-        with pytest.raises(ValueError, match="Server 'args' must be a list of strings"):
+        with pytest.raises(ConfigValidationError, match="Server 'args' must be a list of strings"):
             MCPServerSpec.from_dict({"command": "node", "args": "not a list"})
 
-        with pytest.raises(ValueError, match="Server 'args' must be a list of strings"):
+        with pytest.raises(ConfigValidationError, match="Server 'args' must be a list of strings"):
             MCPServerSpec.from_dict({"command": "node", "args": [123, "valid"]})
 
     def test_from_dict_invalid_env(self):
@@ -154,10 +155,10 @@ class TestMCPJsonConfig:
         config = MCPJsonConfig()
         server = MCPServerSpec(command="node")
 
-        with pytest.raises(ValueError, match="Server name must be a non-empty string"):
+        with pytest.raises(ConfigValidationError, match="Server name must be a non-empty string"):
             config.add_server("", server)
 
-        with pytest.raises(ValueError, match="Server name must be a non-empty string"):
+        with pytest.raises(ConfigValidationError, match="Server name must be a non-empty string"):
             config.add_server(123, server)
 
     def test_add_server_invalid_type(self):
@@ -272,12 +273,12 @@ class TestMCPJsonConfig:
 
     def test_from_dict_invalid_type(self):
         """Test error handling for invalid data type."""
-        with pytest.raises(ValueError, match="Configuration data must be a dictionary"):
+        with pytest.raises(ConfigValidationError, match="Configuration data must be a dictionary"):
             MCPJsonConfig.from_dict("not a dict")
 
     def test_from_dict_invalid_mcp_servers(self):
         """Test error handling for invalid mcpServers."""
-        with pytest.raises(ValueError, match="'mcpServers' must be a dictionary"):
+        with pytest.raises(ConfigValidationError, match="'mcpServers' must be a dictionary"):
             MCPJsonConfig.from_dict({"mcpServers": "not a dict"})
 
     def test_from_dict_invalid_server_config(self):
@@ -288,12 +289,12 @@ class TestMCPJsonConfig:
             }
         }
 
-        with pytest.raises(ValueError, match="Invalid server configuration for 'bad-server'"):
+        with pytest.raises(ConfigValidationError, match="Invalid server configuration for 'bad-server'"):
             MCPJsonConfig.from_dict(data)
 
     def test_from_dict_invalid_global_shortcut(self):
         """Test error handling for invalid global shortcut."""
-        with pytest.raises(ValueError, match="'globalShortcut' must be a string"):
+        with pytest.raises(ConfigValidationError, match="'globalShortcut' must be a string"):
             MCPJsonConfig.from_dict({"globalShortcut": 123})
 
     def test_json_roundtrip(self):
@@ -627,7 +628,7 @@ class TestMCPJsonConfigFilename:
         config = MCPJsonConfig()  # No filename set
         config.add_server("test", {"command": "java", "args": ["-jar", "app.jar"]})
 
-        with pytest.raises(ValueError, match="No path provided and configuration has no filename"):
+        with pytest.raises(ConfigValidationError, match="No path provided and configuration has no filename"):
             config.save()
 
     def test_round_trip_with_filename_preservation(self):
@@ -1041,7 +1042,7 @@ class TestMCPServerSpecMutations:
         )
 
         # Should raise error when trying to add protection again
-        with pytest.raises(ValueError, match="already configured to use MCP Context Protector"):
+        with pytest.raises(ConfigValidationError, match="already configured to use MCP Context Protector"):
             protected.with_context_protector()
 
     def test_without_context_protector_direct_command(self):
@@ -1140,7 +1141,7 @@ class TestMCPServerSpecMutations:
         """Test error when trying to remove context protector from unprotected server."""
         original = MCPServerSpec(command="node", args=["server.js"])
 
-        with pytest.raises(ValueError, match="not configured to use MCP Context Protector"):
+        with pytest.raises(ConfigValidationError, match="not configured to use MCP Context Protector"):
             original.without_context_protector()
 
     def test_without_context_protector_malformed(self):
@@ -1151,7 +1152,7 @@ class TestMCPServerSpecMutations:
             args=["node", "server.js"],  # Missing --command-args
         )
 
-        with pytest.raises(ValueError, match="Expected --command-args"):
+        with pytest.raises(ConfigValidationError, match="Expected --command-args"):
             malformed.without_context_protector()
 
         # --command-args but no command after it
@@ -1160,7 +1161,7 @@ class TestMCPServerSpecMutations:
             args=["--command-args"],  # No command after --command-args
         )
 
-        with pytest.raises(ValueError, match="No command found after --command-args"):
+        with pytest.raises(ConfigValidationError, match="No command found after --command-args"):
             malformed2.without_context_protector()
 
     def test_round_trip_transformation(self):

--- a/test/test_mcp_multi_schema.py
+++ b/test/test_mcp_multi_schema.py
@@ -7,6 +7,7 @@ from unittest.mock import patch
 
 import pytest
 
+from contextprotector.errors import ConfigValidationError
 from contextprotector.mcp_json_config import (
     MCPConfigManagerFactory,
     MCPServerSpec,
@@ -53,7 +54,7 @@ class TestSchemaDetection:
         """Test error handling for invalid schema."""
         data = {"invalidKey": "value"}
 
-        with pytest.raises(ValueError, match="Unknown or invalid MCP configuration schema"):
+        with pytest.raises(ConfigValidationError, match="Unknown or invalid MCP configuration schema"):
             SchemaDetector.detect_schema(data)
 
 
@@ -119,10 +120,10 @@ class TestStandardMCPSchema:
         schema = StandardMCPSchema()
         data = {"mcpServers": {"server1": {"command": "echo"}}}
 
-        with pytest.raises(ValueError, match="does not support environments"):
+        with pytest.raises(ConfigValidationError, match="does not support environments"):
             schema.get_servers(data, environment="dev")
 
-        with pytest.raises(ValueError, match="does not support environments"):
+        with pytest.raises(ConfigValidationError, match="does not support environments"):
             schema.set_servers(data, {}, environment="dev")
 
 

--- a/test/test_quarantine_release_simple.py
+++ b/test/test_quarantine_release_simple.py
@@ -10,6 +10,7 @@ from typing import Any
 
 import pytest
 
+from contextprotector.errors import QuarantineError
 from contextprotector.guardrail_providers.mock_provider import MockGuardrailProvider
 from contextprotector.mcp_wrapper import MCPWrapperServer
 from contextprotector.quarantine import ToolResponseQuarantine
@@ -139,5 +140,5 @@ async def test_quarantine_release_invalid_uuid(setup_quarantine_test: Any) -> No
     )
 
     # Call the quarantine_release tool handler with an invalid UUID
-    with pytest.raises(ValueError, match="No quarantined response found"):
+    with pytest.raises(QuarantineError, match="No quarantined response found"):
         await wrapper._handle_quarantine_release({"uuid": "invalid-uuid"})

--- a/test/test_quarantine_release_tool.py
+++ b/test/test_quarantine_release_tool.py
@@ -11,6 +11,7 @@ from typing import Any
 import pytest
 from mcp import types
 
+from contextprotector.errors import QuarantineError
 from contextprotector.guardrail_providers.mock_provider import MockGuardrailProvider
 from contextprotector.mcp_wrapper import MCPWrapperServer
 from contextprotector.quarantine import ToolResponseQuarantine
@@ -168,7 +169,7 @@ async def test_quarantine_release_invalid_uuid(setup_quarantine_test: Any) -> No
     )
 
     # Call the quarantine_release tool handler with an invalid UUID
-    with pytest.raises(ValueError, match="No quarantined response found"):
+    with pytest.raises(QuarantineError, match="No quarantined response found"):
         await wrapper._handle_quarantine_release({"uuid": "invalid-uuid"})
 
 
@@ -184,5 +185,5 @@ async def test_quarantine_release_missing_uuid(setup_quarantine_test: Any) -> No
     )
 
     # Call the quarantine_release tool handler without a UUID
-    with pytest.raises(ValueError, match="Missing required parameter"):
+    with pytest.raises(QuarantineError, match="Missing required parameter"):
         await wrapper._handle_quarantine_release({})


### PR DESCRIPTION
## Summary

Addresses #21 — replaces all generic \ValueError\ raises across the codebase with semantically meaningful exception types from a new \contextprotector.errors\ module.

## What changed

- **New module \contextprotector/errors.py\** with a complete exception hierarchy rooted at \ContextProtectorError\:
  - Configuration errors: \ConfigValidationError\, \ConfigLoadError\, \ConfigConversionError\
  - Connection errors: \ConnectionConfigError\, \ConnectionFailedError\, \ChildServerNotConnectedError\
  - Runtime errors: \ToolBlockedError\, \ServerPinMismatchError\, \QuarantineError\
- All exception types inherit from both \ContextProtectorError\ (for catch-all handling) and the relevant Python built-in (\ValueError\, \ConnectionError\, or \RuntimeError\) for backward compatibility
- **\mcp_wrapper.py\**: replaced 17 bare \ValueError\ raises (\ConnectionConfigError\, \ConnectionFailedError\, \QuarantineError\)
- **\wrapper_config.py\**: replaced 5 bare \ValueError\ raises and 1 bare \ConnectionConfigError\ (added descriptive messages)
- **\mcp_config.py\**: replaced bare \ValueError\ with \ConfigValidationError\
- **\mcp_json_config.py\**: replaced 22 bare \ValueError\ raises with appropriate typed exceptions
- **\mcp_json_cli.py\**: replaced bare \ValueError\ with \ConfigValidationError\
- **Tests**: updated all \pytest.raises(ValueError)\ assertions to expect the specific exception types
- **\__init__.py\**: exports all exception types as part of the public API

## Backward compatibility

All custom exceptions inherit from their respective Python built-ins (\ValueError\, \ConnectionError\, \RuntimeError\), so existing \except ValueError\ blocks will continue to work unchanged.

## Verification

- All 12 modified files pass AST parsing and \uff\ linting
- Import and inheritance chains verified: \ConnectionFailedError\ is both a \ContextProtectorError\ and a \ConnectionError\
- Test files updated to assert specific exception types where appropriate